### PR TITLE
Fix has host bits set (ipv6)

### DIFF
--- a/agent/nmap_agent.py
+++ b/agent/nmap_agent.py
@@ -99,9 +99,9 @@ class NmapAgent(
             mask = int(message.data.get("mask", "64"))
             max_mask = int(self.args.get("max_network_mask_ipv6", "64"))
             if mask < max_mask:
-                for subnet in ipaddress.ip_network(f"{host}/{mask}").subnets(
-                    new_prefix=max_mask
-                ):
+                for subnet in ipaddress.ip_network(
+                    f"{host}/{mask}", strict=False
+                ).subnets(new_prefix=max_mask):
                     hosts.append((str(subnet.network_address), max_mask))
             else:
                 hosts = [(host, mask)]

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -111,7 +111,7 @@ args:
   - name: "max_network_mask_ipv6"
     type: "int"
     description: "When scanning an IP range, maximum network size, if the network is above max, network in divided into subnetworks."
-    value: 120
+    value: 64
   - name: "scope_domain_regex"
     type: "string"
     description: "Regular expression to define domain scanning scope."

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -242,3 +242,16 @@ def junk_msg() -> message.Message:
         selector="v3.asset.ip",
         data={"version": 4, "host": "0.0.0.0"},
     )
+
+
+@pytest.fixture
+def ipv6_msg() -> message.Message:
+    """Creates a dummy message of type v3.asset.ip.v6 for testing purposes."""
+    return message.Message.from_data(
+        selector="v3.asset.ip.v6",
+        data={
+            "version": 6,
+            "host": "2600:3c01:224a:6e00:f03c:91ff:fe18:bb2f",
+            "mask": "64",
+        },
+    )


### PR DESCRIPTION
The error: `ValueError: 2600:9000:224a:6e00:19:74a:4c80:93a1/64 has host bits set.`

The fix proposed: 
`ipaddress.ip_network` is expecting just the network address, example:
![image](https://github.com/Ostorlab/agent_nmap/assets/144013278/e97af620-b255-440b-875d-2c2c40b5eb95)

But when passing ip address with host bits it raise the error:
![image](https://github.com/Ostorlab/agent_nmap/assets/144013278/802810da-95fe-479c-8f6c-4dbd90a69db9)

To avoid that we can pass `strict` flag as false, which mean avoid host bits:
![image](https://github.com/Ostorlab/agent_nmap/assets/144013278/ded099cc-c882-458a-a277-4512f6e20c36)

