### PR TITLE
Update from python3.10 to 3.11

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -20,7 +20,7 @@ warn_unused_ignores = True
 disallow_any_unimported = True
 warn_return_any = True
 exclude = .*_pb2.py
-python_version = 3.10
+python_version = 3.11
 
 [mypy-pytablewriter.*]
 implicit_reexport = True

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y software-properties-common
-RUN add-apt-repository ppa:deadsnakes/ppa
-RUN apt-get remove -y python*
+RUN apt-get update && apt-get install -y software-properties-common  \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get remove -y python*
+
 RUN apt-get install -y build-essential \
     python3.11 \
     python3.11-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,19 @@
 FROM ubuntu:22.04
 RUN apt-get update && apt-get install -y build-essential \
-                                        python3.10 \
-                                        python3.10-dev \
+                                        python3.11 \
+                                        python3.11-dev \
                                         python3-pip \
                                         wireguard \
                                         iproute2 \
                                         openresolv \
                                         nmap \
                                         && \
-                                        python3.10 -m pip install --upgrade pip
+                                        python3.11 -m pip install --upgrade pip
 COPY requirement.txt /requirement.txt
-RUN python3 -m pip install -r /requirement.txt
+RUN python3.11 -m pip install -r /requirement.txt
 RUN mkdir -p /app/agent
 ENV PYTHONPATH=/app
 COPY agent /app/agent
 COPY ostorlab.yaml /app/agent/ostorlab.yaml
 WORKDIR /app
-CMD ["python3", "/app/agent/nmap_agent.py"]
-
-
+CMD ["python3.11", "/app/agent/nmap_agent.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,19 @@
 FROM ubuntu:22.04
-RUN apt-get update && apt-get install -y build-essential \
-                                        python3.11 \
-                                        python3.11-dev \
-                                        python3-pip \
-                                        wireguard \
-                                        iproute2 \
-                                        openresolv \
-                                        nmap \
-                                        && \
-                                        python3.11 -m pip install --upgrade pip
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y software-properties-common
+RUN add-apt-repository ppa:deadsnakes/ppa
+RUN apt-get remove -y python*
+RUN apt-get install -y build-essential \
+    python3.11 \
+    python3.11-dev \
+    python3-pip \
+    wireguard \
+    iproute2 \
+    openresolv \
+    nmap
+
+RUN python3.11 -m pip install --upgrade pip
 COPY requirement.txt /requirement.txt
 RUN python3.11 -m pip install -r /requirement.txt
 RUN mkdir -p /app/agent

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -1,6 +1,6 @@
 kind: Agent
 name: nmap
-version: 0.9.2
+version: 0.10.0
 image: images/logo.png
 description: |
   This repository is an implementation of [Ostorlab Agent](https://pypi.org/project/ostorlab/) for the [Nmap Scanner](https://github.com/projectdiscovery/nmap) by Project Discovery.

--- a/requirement.txt
+++ b/requirement.txt
@@ -2,4 +2,3 @@ ostorlab[agent]
 xmltodict
 pytablewriter
 rich
-async_timeout

--- a/requirement.txt
+++ b/requirement.txt
@@ -2,3 +2,4 @@ ostorlab[agent]
 xmltodict
 pytablewriter
 rich
+async_timeout


### PR DESCRIPTION
**Update from python3.10 to 3.11:**

Steps:
- update python-version in .github/workflows/pylint.yml
- update python-version in .github/workflows/pytest.yml
- update python-version in .github/workflows/mypy.ini
- update python-version in docker file

Steps to test the new version:

- run unit tests using python 3.11 in virtual env

```bash
virtualenv -p python3.11 venv
source venv/bin/activate
pip install -r requirement.txt
pip install -r tests/test-requirement.txt

mypy agent/ tests/
black .
pylint --rcfile=.pylintrc --ignore=tests/ agent/
pylint --rcfile=.pylintrc -d C0103,W0613 tests/
pytest
```

- run test after building the docker image

```bash
ostorlab agent build -f ostorlab.yaml -o dev --no-cache
ostorlab scan run --install --follow=agent/dev/nmap --agent agent/dev/nmap ip 8.8.8.8
```