### PR TITLE
[Feature] - Adding nmap stealth scan to bypass firewalls and decoy scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ Supported agent flags:
 * `timing_template` (`-Tx`): Template of timing settings (T0, T1, ... T5)..
 * `script_default` (`-sC`): Script scan, equivalent to --script=default.
 * `scripts` (`--script`): List of scripts to run using Nmap.
-* `os` (`--os`): Enable OS detection
-
+* `os` (`--os`): Enable OS detection.
+* `decoys` (`-R RND:<number of decoys>`): Makes it seem like decoy hosts are also scanning the target network.
+* `firewall_evasion` : Makes the scan quieter and less noticeable, helping it slip past firewalls.
 
  ### Install directly from OXO agent store
 

--- a/agent/nmap_agent.py
+++ b/agent/nmap_agent.py
@@ -193,6 +193,8 @@ class NmapAgent(
             no_ping=self.args.get("no_ping", False),
             timing_template=nmap_options.TimingTemplate[self.args["timing_template"]],
             scripts=self.args.get("scripts"),
+            firewall_evasion=self.args.get("firewall_evasion", False),
+            decoys=self.args.get("decoys"),
             script_default=self.args.get("script_default", False),
             version_detection=self.args.get("version_info", False),
             os_detection=self.args.get("os", False),

--- a/agent/nmap_agent.py
+++ b/agent/nmap_agent.py
@@ -172,6 +172,8 @@ class NmapAgent(
             no_ping=self.args.get("no_ping", False),
             timing_template=nmap_options.TimingTemplate[self.args["timing_template"]],
             scripts=self.args.get("scripts"),
+            firewall_evasion=self.args.get("firewall_evasion", False),
+            decoys=self.args.get("decoys"),
             script_default=self.args.get("script_default", False),
             version_detection=self.args.get("version_info", False),
         )

--- a/agent/nmap_options.py
+++ b/agent/nmap_options.py
@@ -79,7 +79,7 @@ class NmapOptions:
             command_options.append("-sV")
         return command_options
 
-    def _set_decoys_options(self) -> List[str]:
+    def _set_decoys_options(self) -> list[str]:
         """ using decoys to minimize IPS detection, DISCLAIMER this might increase the likelihood of raising suspicion if service traffic is low"""
         command_options = []
         if self.decoys is not None:

--- a/agent/nmap_options.py
+++ b/agent/nmap_options.py
@@ -83,7 +83,8 @@ class NmapOptions:
         """ using decoys to minimize IPS detection, DISCLAIMER this might increase the likelihood of raising suspicion if service traffic is low"""
         command_options = []
         if self.decoys != None:
-            command_options.append(f"-D RND:{self.decoys}")
+            command_options.append("-D")
+            command_options.append("RND:{self.decoys}")
         return command_options
 
 
@@ -103,7 +104,7 @@ class NmapOptions:
             command_options.append("--source-port")
             command_options.append("80")
             ''' reducing timing template to evade IDSs like snort '''
-            command_options.append("-T2")
+            self.timing_template = TimingTemplate.T2
         return command_options
 
     def _set_host_discovery_options(self) -> List[str]:
@@ -137,7 +138,7 @@ class NmapOptions:
 
     def _set_ports_option(self) -> List[str]:
         """Appends the ports option to the list of nmap options."""
-        if self.fast_mode is True:
+        if self.fast_mode is True and self.firewall_evasion is False:
             return ["-F"]
         elif self.top_ports is not None:
             return ["--top-ports", str(self.top_ports)]
@@ -189,9 +190,9 @@ class NmapOptions:
         command_options.extend(self._set_version_detection_option())
         command_options.extend(self._set_dns_resolution_option())
         command_options.extend(self._set_ports_option())
+        command_options.extend(self._set_firewall_evasion_flags())
         command_options.extend(self._set_timing_option())
         command_options.extend(self._set_port_scanning_techniques())
-        command_options.extend(self._set_firewall_evasion_flags())
         command_options.extend(self._set_decoys_options())
         command_options.extend(self._set_host_discovery_options())
         command_options.extend(self._set_privileged())

--- a/agent/nmap_options.py
+++ b/agent/nmap_options.py
@@ -82,7 +82,7 @@ class NmapOptions:
     def _set_decoys_options(self) -> List[str]:
         """ using decoys to minimize IPS detection, DISCLAIMER this might increase the likelihood of raising suspicion if service traffic is low"""
         command_options = []
-        if self.decoys != None:
+        if self.decoys is not None:
             command_options.append("-D")
             command_options.append("RND:{self.decoys}")
         return command_options

--- a/agent/nmap_options.py
+++ b/agent/nmap_options.py
@@ -92,15 +92,15 @@ class NmapOptions:
         """Adds various techniques to nmap to bypass firewall evasions ref: https://nmap.org/book/man-bypass-firewalls-ids.html"""
         command_options = []
         if self.firewall_evasion is True:
-            ''' disabling arp pings, dns resolution, ping host discovery '''
+            # Disabling arp pings, DNS resolution, and ping host discovery.
             command_options.append("--disable-arp-ping")
             command_options.append("-Pn")
             command_options.append("-n")
-            ''' request fragmentation to bypass custom packet filters '''
+            # Request fragmentation to bypass custom packet filters.
             command_options.append("-f")
             command_options.append("--mtu")
             command_options.append("8")
-            ''' scans from http might be interpreted as false positives '''
+            # Scans from HTTP port might be interpreted as false positives
             command_options.append("--source-port")
             command_options.append("80")
             ''' reducing timing template to evade IDSs like snort '''

--- a/agent/nmap_options.py
+++ b/agent/nmap_options.py
@@ -83,7 +83,7 @@ class NmapOptions:
         """ using decoys to minimize IPS detection, DISCLAIMER this might increase the likelihood of raising suspicion if service traffic is low"""
         command_options = []
         if self.decoys != None:
-            command_options.append(f"-R RND:{self.decoys}")
+            command_options.append(f"-D RND:{self.decoys}")
         return command_options
 
 
@@ -97,9 +97,11 @@ class NmapOptions:
             command_options.append("-n")
             ''' request fragmentation to bypass custom packet filters '''
             command_options.append("-f")
-            command_options.append("--mtu 8")
+            command_options.append("--mtu")
+            command_options.append("8")
             ''' scans from http might be interpreted as false positives '''
-            command_options.append("--source-port 80")
+            command_options.append("--source-port")
+            command_options.append("80")
             ''' reducing timing template to evade IDSs like snort '''
             command_options.append("-T2")
         return command_options
@@ -127,7 +129,8 @@ class NmapOptions:
             command_options.append("-R")
             if self.dns_servers:
                 dns_servers = ",".join([str(dns) for dns in self.dns_servers])
-                command_options.append(f"--dns-servers {dns_servers}")
+                command_options.append("--dns-servers")
+                command_options.append(dns_servers)
         else:
             command_options.append("-n")
         return command_options

--- a/agent/nmap_options.py
+++ b/agent/nmap_options.py
@@ -84,7 +84,7 @@ class NmapOptions:
         command_options = []
         if self.decoys is not None:
             command_options.append("-D")
-            command_options.append("RND:{self.decoys}")
+            command_options.append(f"RND:{self.decoys}")
         return command_options
 
 

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -104,6 +104,13 @@ args:
     type: "string"
     description: "Template of timing settings (T0, T1, ... T5)."
     value: "T5"
+  - name: "firewall_evasion"
+    type: "boolean"
+    description: "Makes the scan quieter and less noticeable, helping it slip past firewalls."
+    value: false
+  - name: "decoys"
+    type: "number"
+    description: "Makes it seem like decoy hosts are also scanning the target network."
   - name: "script_default"
     type: "boolean"
     description: "Script scan, equivalent to --script=default"


### PR DESCRIPTION
Added support for Nmap stealth scans to bypass firewalls and slip past IPS/IDS systems, used techniques from the [Nmap documentation](https://nmap.org/book/man-bypass-firewalls-ids.html). 

Also included decoy scans to make it harder to trace the user's real IP by creating fake sources. 
