### PR TITLE
Return empty dict instead of raising xml.parsers.expat.ExpatError for the second time

### DIFF
--- a/agent/nmap_agent.py
+++ b/agent/nmap_agent.py
@@ -533,7 +533,7 @@ class NmapAgent(
 
         except subprocess.CalledProcessError as e:
             raise RunCommandError(
-                f'An error occurred while running the command {" ".join(command)}'
+                f"An error occurred while running the command {' '.join(command)}"
             ) from e
         except subprocess.TimeoutExpired:
             logger.warning("Command timed out for command %s", " ".join(command))

--- a/agent/nmap_wrapper.py
+++ b/agent/nmap_wrapper.py
@@ -32,7 +32,7 @@ def parse_output(xml_output: str) -> dict[str, Any]:
         logger.error(
             "Error parsing XML output: %s - XML output: %s", parsing_error, xml_output
         )
-        raise
+        return {}
 
 
 class NmapWrapper:

--- a/agent/nmap_wrapper.py
+++ b/agent/nmap_wrapper.py
@@ -3,7 +3,7 @@
 import ipaddress
 import logging
 import subprocess
-import xml
+from xml.parsers import expat
 from typing import Any, Dict, List, Tuple
 
 import xmltodict
@@ -28,7 +28,7 @@ def parse_output(xml_output: str) -> dict[str, Any]:
     try:
         parsed_xml: dict[str, Any] = xmltodict.parse(xml_output, disable_entities=True)
         return parsed_xml
-    except xml.parsers.expat.ExpatError as parsing_error:
+    except expat.ExpatError as parsing_error:
         logger.error(
             "Error parsing XML output: %s - XML output: %s", parsing_error, xml_output
         )

--- a/tests/nmap_wrapper_test.py
+++ b/tests/nmap_wrapper_test.py
@@ -1,9 +1,7 @@
 """Nmap wrapper unit tests"""
 
-import xml
 import pathlib
-
-import pytest
+from unittest import mock
 
 import agent.nmap_agent
 from agent import nmap_options
@@ -126,15 +124,18 @@ def testNmapWrapper_whenAllTopPortsUsed_returnCommand(
     ]
 
 
-def testNmapWrapperParseOutput_whenXmlIsInvalid_catchesAndReraisesError() -> None:
+def testNmapWrapperParseOutput_whenXmlIsInvalid_catchesAndReturnEmptyDict() -> None:
     """Tests parsing invalid XML output scan results. Should catch the error and re-raise it."""
     invalid_xml = (pathlib.Path(__file__).parent / "malformed_output.xml").read_text()
-    parsed_output = None
 
-    with pytest.raises(xml.parsers.expat.ExpatError):
+    with mock.patch("agent.nmap_wrapper.logger") as mock_logger:
         parsed_output = nmap_wrapper.parse_output(invalid_xml)
 
-    assert parsed_output is None
+        assert parsed_output == {}
+
+        mock_logger.error.assert_called_once_with(
+            "Error parsing XML output: %s - XML output: %s", mock.ANY, invalid_xml
+        )
 
 
 def testNmapWrapperParseOutput_whenXmlIsValid_returnsParsedXml() -> None:


### PR DESCRIPTION
## PR Description


This PR is part of **Fixit!**. The issue being addressed occurs when `xml.parsers.expat.ExpatError` is raised in the `parse_output()` function in `nmap_wrapper.py`. Previously, the function would log the error and raise it again. The updated behavior now returns an empty dictionary instead of raising the error.

### Changes Made:
- Modified the `parse_output()` function to return an empty dictionary when `xml.parsers.expat.ExpatError` get raised.
