### PR TITLE
feature: add ability to set host-timeout argument

### DIFF
--- a/agent/nmap_agent.py
+++ b/agent/nmap_agent.py
@@ -74,6 +74,7 @@ class NmapAgent(
         self._scope_domain_regex: Optional[str] = self.args.get("scope_domain_regex")
         self._vpn_config: Optional[str] = self.args.get("vpn_config")
         self._dns_config: Optional[str] = self.args.get("dns_config")
+        self._host_timeout: Optional[int] = self.args.get("host_timeout")
 
     def start(self) -> None:
         if self._vpn_config is not None and self._dns_config is not None:
@@ -174,6 +175,7 @@ class NmapAgent(
             scripts=self.args.get("scripts"),
             script_default=self.args.get("script_default", False),
             version_detection=self.args.get("version_info", False),
+            host_timeout=self._host_timeout,
         )
         client = nmap_wrapper.NmapWrapper(options)
 
@@ -194,6 +196,7 @@ class NmapAgent(
             script_default=self.args.get("script_default", False),
             version_detection=self.args.get("version_info", False),
             os_detection=self.args.get("os", False),
+            host_timeout=self._host_timeout,
         )
         client = nmap_wrapper.NmapWrapper(options)
         logger.info("scanning domain %s with options %s", domain_name, options)

--- a/agent/nmap_options.py
+++ b/agent/nmap_options.py
@@ -151,7 +151,7 @@ class NmapOptions:
                 command += ["--script", script]
 
         return command
-    
+
     def _set_host_timeout(self) -> List[str]:
         if self.host_timeout is not None:
             return ["--host-timeout", str(self.host_timeout)]

--- a/agent/nmap_options.py
+++ b/agent/nmap_options.py
@@ -62,6 +62,7 @@ class NmapOptions:
     )
     no_ping: bool = True
     privileged: Optional[bool] = None
+    host_timeout: Optional[int] = None
 
     def _set_os_detection_option(self) -> List[str]:
         """Appends the os detection option to the list of nmap options."""
@@ -150,6 +151,12 @@ class NmapOptions:
                 command += ["--script", script]
 
         return command
+    
+    def _set_host_timeout(self) -> List[str]:
+        if self.host_timeout is not None:
+            return ["--host-timeout", str(self.host_timeout)]
+        else:
+            return []
 
     @property
     def command_options(self) -> List[str]:
@@ -165,4 +172,5 @@ class NmapOptions:
         command_options.extend(self._set_privileged())
         command_options.extend(self._set_scripts())
         command_options.extend(self._set_script_default())
+        command_options.extend(self._set_host_timeout())
         return command_options

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -1,6 +1,6 @@
 kind: Agent
 name: nmap
-version: 1.5.2
+version: 1.5.3
 image: images/logo.png
 description: |
   This repository is an implementation of [Ostorlab Agent](https://pypi.org/project/ostorlab/) for the [Nmap Scanner](https://github.com/projectdiscovery/nmap) by Project Discovery.
@@ -123,6 +123,10 @@ args:
   - name: "scope_domain_regex"
     type: "string"
     description: "Regular expression to define domain scanning scope."
+  - name: "host_timeout"
+    type: "number"
+    description: "Host timeout in seconds."
+    value: 900
   - name: "vpn_config"
     type: "string"
     description: "Vpn configuration."


### PR DESCRIPTION
Added ability to set `--host-timeout` in args. By default, [nmap T5 timings have 15 minutes timeout](https://nmap.org/book/performance-timing-templates.html), which can significantly lengthen the scan if it contains dead hosts.
This PR doesn't change the default behaviour of agent.