### PR TITLE
fix: Use correct product name when reporting fingerprint details.

### DIFF
--- a/agent/nmap_agent.py
+++ b/agent/nmap_agent.py
@@ -482,7 +482,7 @@ class NmapAgent(
                                 "library_name": data_product,
                                 "library_version": data.get("product_version"),
                                 "library_type": "BACKEND_COMPONENT",
-                                "detail": f"Nmap Detected {data.get('service')} on {domain_name}",
+                                "detail": f"Nmap Detected {data_product} on {domain_name}",
                             }
                             self.emit(
                                 selector="v3.fingerprint.domain_name.service.library",
@@ -496,7 +496,7 @@ class NmapAgent(
                                 "library_name": data_banner,
                                 "library_version": None,
                                 "library_type": "BACKEND_COMPONENT",
-                                "detail": f"Nmap Detected {data.get('service')} on {domain_name}",
+                                "detail": f"Nmap Detected {data_banner} on {domain_name}",
                             }
                             self.emit(
                                 selector="v3.fingerprint.domain_name.service.library",

--- a/tests/nmap_agent_test.py
+++ b/tests/nmap_agent_test.py
@@ -693,14 +693,15 @@ def testAgentNmapOptions_whenServiceHasProduct_reportsFingerprint(
     assert any("F5 BIG" in m.data.get("library_name", "") for m in agent_mock) is True
     assert (
         any(
-            m.data.get("detail") == "Nmap Detected http-proxy on ostorlab.co"
+            m.data.get("detail")
+            == "Nmap Detected F5 BIG-IP load balancer http proxy on ostorlab.co"
             for m in agent_mock
         )
         is True
     )
     assert (
         any(
-            m.data.get("detail") == "Nmap Detected http on ostorlab.co"
+            m.data.get("detail") == "Nmap Detected Apache httpd on ostorlab.co"
             for m in agent_mock
         )
         is True


### PR DESCRIPTION
The current  implementation  constructs the technical detail of the detected fingerprint by using the `service` field of the `Nmap` output which gives results similar to: 
`SSH-2.0-WeOnlyDo-WingFTP  Nmap Detected None on <redacted>`.
This PR fixes the bug, by simply using the same library name that is emitted as a fingerprint message.