### PR TITLE
feature: compile nmap

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 .dockerignore
 Dockerfile
+Dockerfile.compiled
 requirements.txt
 .github
 tests

--- a/Dockerfile.compiled
+++ b/Dockerfile.compiled
@@ -1,0 +1,132 @@
+FROM python:3.14-bookworm AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV CC=clang
+
+# Install build dependencies including clang for fast Nuitka builds
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    wget \
+    automake \
+    clang \
+    lld \
+    patchelf \
+    wireguard \
+    iproute2 \
+    openresolv \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python -m pip install --upgrade pip
+
+# Install Python dependencies + Nuitka
+COPY requirement.txt /requirement.txt
+RUN pip install -r /requirement.txt nuitka
+RUN rm /requirement.txt
+
+# Compile nmap from source
+ARG NMAP_VERSION=7.95
+WORKDIR /tmp
+RUN wget https://nmap.org/dist/nmap-${NMAP_VERSION}.tar.bz2 \
+    && tar jxvf nmap-${NMAP_VERSION}.tar.bz2 \
+    && cd /tmp/nmap-${NMAP_VERSION} \
+    && ./configure --without-zenmap \
+    && make -j$(nproc) \
+    && make install \
+    && cd / \
+    && rm -rf /tmp/nmap-${NMAP_VERSION}
+
+# Copy agent source
+WORKDIR /app
+COPY agent /app/agent
+COPY ostorlab.compiled.yaml /app/ostorlab.yaml
+
+# Shared Nuitka helper
+RUN cat > /nuitka_build.sh <<'NUITKA_SCRIPT'
+#!/bin/bash
+set -e
+exec python -m nuitka --standalone \
+    --clang \
+    --lto=no \
+    --jobs=$(nproc) \
+    --enable-plugin=anti-bloat \
+    --include-package=agent \
+    --include-package=ostorlab \
+    --include-package=rich \
+    --include-package=xmltodict \
+    --include-package=pytablewriter \
+    --include-package=fastmcp \
+    --include-package=uvicorn \
+    --include-package=websockets \
+    --include-package=requests \
+    --include-package=pyaxmlparser \
+    --include-package=google.protobuf \
+    --include-package=ostorlab.agent.message.proto \
+    --include-distribution-metadata=aiormq \
+    --include-distribution-metadata=aio-pika \
+    --include-distribution-metadata=opentelemetry-api \
+    --include-distribution-metadata=mcp \
+    --include-distribution-metadata=fastmcp \
+    --include-distribution-metadata=click \
+    --include-distribution-metadata=Flask \
+    --include-distribution-metadata=Werkzeug \
+    --include-distribution-metadata=websockets \
+    --include-distribution-metadata=MarkupSafe \
+    --include-distribution-metadata=itsdangerous \
+    --include-distribution-metadata=cyclopts \
+    --include-distribution-metadata=Authlib \
+    --include-distribution-metadata=dnspython \
+    --include-data-dir=$(python -c "import ostorlab.agent.schema; print(ostorlab.agent.schema.__path__[0])")=ostorlab/agent/schema \
+    --include-data-dir=$(python -c "import ostorlab.agent.kb; print(ostorlab.agent.kb.__path__[0])")=ostorlab/agent/kb \
+    "$@"
+NUITKA_SCRIPT
+RUN chmod +x /nuitka_build.sh
+
+# Compile main agent binary
+RUN /nuitka_build.sh \
+    --include-data-files=/app/ostorlab.yaml=ostorlab.yaml \
+    --output-dir=/app/build \
+    /app/agent/nmap_agent.py
+
+# Compile MCP server binary
+RUN /nuitka_build.sh \
+    --output-dir=/app/build \
+    /app/agent/mcp/server.py
+
+# Copy protobuf .py files required by ostorlab serializer (os.walk looks for .py on disk)
+RUN mkdir -p /app/build/nmap_agent.dist/ostorlab/agent/message \
+    && mkdir -p /app/build/server.dist/ostorlab/agent/message \
+    && cp -r $(python -c "import ostorlab.agent.message; print(ostorlab.agent.message.__path__[0])")/proto \
+       /app/build/nmap_agent.dist/ostorlab/agent/message/proto \
+    && cp -r $(python -c "import ostorlab.agent.message; print(ostorlab.agent.message.__path__[0])")/proto \
+       /app/build/server.dist/ostorlab/agent/message/proto
+
+
+FROM debian:bookworm-slim
+
+# Runtime dependencies:
+# - wireguard-tools, iproute2, openresolv: required by wg-quick / VPN logic
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libpcap0.8 \
+    wireguard-tools \
+    iproute2 \
+    python3 \
+    python3-pip \
+    openresolv \
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
+RUN pip3 install ostorlab --break-system-packages
+
+# Copy compiled nmap binary + data
+COPY --from=builder /usr/local/bin/nmap /usr/local/bin/nmap
+COPY --from=builder /usr/local/share/nmap /usr/local/share/nmap
+
+# Copy compiled binaries
+COPY --from=builder /app/build/nmap_agent.dist /app/nmap_agent
+COPY --from=builder /app/build/server.dist /app/mcp_server
+
+WORKDIR /app
+ENV PATH="/app/nmap_agent:/app/mcp_server:${PATH}"
+
+RUN ln -s /app/nmap_agent/ostorlab.yaml /tmp/ostorlab.yaml
+
+CMD ["/app/nmap_agent/nmap_agent.bin"]

--- a/agent/mcp/runner.py
+++ b/agent/mcp/runner.py
@@ -4,14 +4,14 @@ import subprocess
 logger = logging.getLogger(__name__)
 
 RUN_SERVER_PATH = "/app/agent/mcp/server.py"
+RUN_SERVER_PATH_COMPILED = "/app/mcp_server/server.bin"
 
 
-def run() -> None:
+def run(is_compiled: bool = False) -> None:
     """Start the MCP server with the streamable-http transport."""
     logger.info("Starting MCP server.")
     subprocess.Popen(
         [
-            "python3.14",
-            RUN_SERVER_PATH,
+            RUN_SERVER_PATH if is_compiled is False else RUN_SERVER_PATH_COMPILED,
         ]
     )

--- a/agent/nmap_agent.py
+++ b/agent/nmap_agent.py
@@ -75,6 +75,7 @@ class NmapAgent(
         self._vpn_config: Optional[str] = self.args.get("vpn_config")
         self._dns_config: Optional[str] = self.args.get("dns_config")
         self._host_timeout: Optional[int] = self.args.get("host_timeout")
+        self._is_compiled: bool = self.args.get("is_compiled", False)
 
         self.should_start_mcp_server: bool = self.args.get(
             "should_start_mcp_server", False
@@ -86,7 +87,7 @@ class NmapAgent(
 
         if self.should_start_mcp_server is True:
             logger.info("Running Nmap agent in MCP mode.")
-            mcp_runner.run()
+            mcp_runner.run(is_compiled=self._is_compiled)
 
     def process(self, message: msg.Message) -> None:
         """Process messages of type v3.asset.ip.[v4,v6] and performs a network scan. Once the scan is completed, it

--- a/ostorlab.compiled.yaml
+++ b/ostorlab.compiled.yaml
@@ -1,0 +1,145 @@
+kind: Agent
+name: nmap_compiled
+version: 2.0.0
+image: images/logo.png
+description: |
+  This repository is an implementation of [Ostorlab Agent](https://pypi.org/project/ostorlab/) for the [Nmap Scanner](https://github.com/projectdiscovery/nmap) by Project Discovery.
+  ## Getting Started
+  To perform your first scan, simply run the following command:
+  ```shell
+  ostorlab scan run --install --agent agent/ostorlab/nmap ip 8.8.8.8
+  ```
+  This command will download and install `agent/ostorlab/nmap` and target the ip `8.8.8.8`.
+  For more information, please refer to the [Ostorlab Documentation](https://github.com/Ostorlab/ostorlab/blob/main/README.md)
+  ## Usage
+
+  Agent Nmap can be installed directly from the ostorlab agent store or built from this repository.
+  
+  Supported agent flags:
+  
+  * `fast_mode` (`-F`): Fast mode scans fewer ports than the default mode.
+  * `ports` (`-p`): List of ports to scan.
+  * `top_ports` (`--top-ports`): Top ports to scan.
+  * `no_ping` (`-Pn`): Treat all hosts as online, skip host discovery.
+  * `version_info` (`-sV`): Probe open ports to determine service/version info.
+  * `timing_template` (`-Tx`): Template of timing settings (T0, T1, ... T5)..
+  * `script_default` (`-sC`): Script scan, equivalent to --script=default.
+  * `scripts` (`--script`): List of scripts to run using Nmap.
+  
+   ### Install directly from ostorlab agent store
+   ```shell
+   ostorlab agent install agent/ostorlab/nmap
+   ```
+   You can then run the agent with the following command:
+   ```shell
+   ostorlab scan run --agent agent/ostorlab/nmap ip 8.8.8.8
+   ```
+   ### Build directly from the repository
+    1. To build the nmap agent you need to have [ostorlab](https://pypi.org/project/ostorlab/) installed in your machine.  if you have already installed ostorlab, you can skip this step.
+   ```shell
+   pip3 install ostorlab
+   ```
+    2. Clone this repository.
+   ```shell
+   git clone https://github.com/Ostorlab/agent_nmap.git && cd agent_nmap
+   ```
+    3. Build the agent image using ostorlab cli.
+   ```shell
+   ostorlab agent build --file=ostorlab.compiled.yaml
+   ```
+   You can pass the optional flag `--organization` to specify your organisation. The organization is empty by default.
+   4. Run the agent using on of the following commands:
+     * If you did not specify an organization when building the image:
+      ```shell
+      ostorlab scan run --agent agent//nmap ip 8.8.8.8
+      ```
+     * If you specified an organization when building the image:
+      ```shell
+      ostorlab scan run --agent agent/[ORGANIZATION]/nmap ip 8.8.8.8
+      ```
+   ## License
+   [Apache-2.0](./LICENSE)
+license: Apache-2.0
+source: https://github.com/Ostorlab/agent_nmap
+in_selectors:
+  - v3.asset.ip.v4
+  - v3.asset.ip.v6
+  - v3.asset.domain_name
+  - v3.asset.link
+  - v3.asset.file.api_schema
+out_selectors:
+  - v3.asset.ip.v4.port.service
+  - v3.asset.ip.v6.port.service
+  - v3.asset.domain_name.service
+  - v3.report.vulnerability
+  - v3.fingerprint.ip.v4.service.library
+  - v3.fingerprint.ip.v6.service.library
+  - v3.fingerprint.domain_name.service.library
+docker_file_path : Dockerfile.compiled
+service_name: "nmap"
+docker_build_root : .
+args:
+  - name: "fast_mode"
+    description: "Fast mode scans fewer ports than the default mode."
+    type: "boolean"
+    value: false
+  - name: "ports"
+    type: "string"
+    description: "List of ports to scan."
+    value: "0-65535"
+  - name: "tcp_syn_ping_ports"
+    type: "string"
+    description: "List of ports to use for host discovery (-PS). Accepts list of ports: 21,22... OR a range 0-100"
+    value: "21,22,25,53,68,80,110,123,143,443,465,631,993,995,3306,3389,8080"
+  - name: "top_ports"
+    type: "number"
+    description: "Top ports to scan."
+  - name: "no_ping"
+    description: "Treat all hosts as online, skip host discovery."
+    type: "boolean"
+    value: false
+  - name: "version_info"
+    description: "Probe open ports to determine service/version info."
+    type: "boolean"
+    value: true
+  - name: "timing_template"
+    type: "string"
+    description: "Template of timing settings (T0, T1, ... T5)."
+    value: "T5"
+  - name: "script_default"
+    type: "boolean"
+    description: "Script scan, equivalent to --script=default"
+    value: true
+  - name: "scripts"
+    type: "array"
+    description: "List of scripts to run using Nmap"
+    value: ['banner']
+  - name: "max_network_mask_ipv4"
+    type: "number"
+    description: "When scanning an IP range, maximum network size, if the network is above max, network in divided into subnetworks."
+    value: 26
+  - name: "max_network_mask_ipv6"
+    type: "number"
+    description: "When scanning an IP range, maximum network size, if the network is above max, network in divided into subnetworks."
+    value: 112
+  - name: "scope_domain_regex"
+    type: "string"
+    description: "Regular expression to define domain scanning scope."
+  - name: "host_timeout"
+    type: "number"
+    description: "Host timeout in seconds."
+    value: 900
+  - name: "vpn_config"
+    type: "string"
+    description: "Vpn configuration."
+  - name: "dns_config"
+    type: "string"
+    description: "DNS configuration."
+  - name: "should_start_mcp_server"
+    type: "boolean"
+    description: "True if the agent should run as an MCP server."
+    value: false
+  - name: "is_compiled"
+    description: "True if the agent is compiled, false if it is running from source code."
+    type: "boolean"
+    value: true

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -139,4 +139,7 @@ args:
     type: "boolean"
     description: "True if the agent should run as an MCP server."
     value: false
-
+  - name: "is_compiled"
+    description: "True if the agent is compiled, false if it is running from source code."
+    type: "boolean"
+    value: false


### PR DESCRIPTION
Add support for compiling the Nmap agent using Nuitka to produce standalone binaries.

**Usage** :
- Build the compiled variant:
```ostorlab agent build --file=ostorlab.compiled.yaml -o <org>```
- Build the standard (source) variant (unchanged):
```ostorlab agent build --file=ostorlab.yaml  -o <org>```