### PR TITLE
fix: remove codecov config

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -44,6 +44,6 @@ jobs:
           sudo apt-get install nmap
       - name: Running tests with pytest.
         run: |
-          
+          set -o pipefail
           pytest -m "not docker"  --cov=./
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -45,5 +45,5 @@ jobs:
       - name: Running tests with pytest.
         run: |
           set -o pipefail
-          pytest -m "not docker"  --cov=./
+          pytest -m "not docker"
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -44,11 +44,6 @@ jobs:
           sudo apt-get install nmap
       - name: Running tests with pytest.
         run: |
-          set -o pipefail
+          
           pytest -m "not docker"  --cov=./
 
-      - name: Upload coverage to Codecov.
-        uses: codecov/codecov-action@v4
-        with:
-          verbose: true
-          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Removes the codecov config file and the coverage upload from the pytest workflow